### PR TITLE
Documentation, added missing tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compose-validatr"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Library for parsing and validating Docker compose manifests"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ This library performs all validation except host device and local files validati
 let yaml = r#"
 services:
   gitlab:
-  image: gitlab/gitlab-ce:latest
-  container_name: gitlab
-  hostname: gitlab
-  restart: always
-  build:
-    context: .
-    dockerfile: webapp.Dockerfile
+    image: gitlab/gitlab-ce:latest
+    container_name: gitlab
+    hostname: gitlab
+    restart: always
+    build:
+      context: .
+      dockerfile: webapp.Dockerfile
 "#;
 
 let compose = Compose::new(yaml).unwrap();

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -15,11 +15,21 @@ use serde_yaml;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Compose {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+
     pub services: HashMap<String, services::Service>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub networks: Option<HashMap<String, Option<networks::Network>>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub volumes: Option<HashMap<String, Option<volumes::Volume>>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub configs: Option<HashMap<String, Option<configs::Config>>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub secrets: Option<HashMap<String, Option<secrets::Secret>>>,
 }
 
@@ -117,7 +127,7 @@ impl Compose {
 
 /// This trait needs to be implemented for top level elements
 pub(crate) trait Validate {
-    /// Validate an attribute is valid within the context of the compose yaml
+    /// Validate that an attribute is valid within the context of the compose yaml
     ///
     /// Push all validation errors to the ValidationErrors so that users are able to see
     /// all of their errors at once, versus incrementally

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -40,7 +40,7 @@ pub struct Compose {
 }
 
 impl Compose {
-    /// Create a new [`Compose`] representation
+    /// Create and validate a [`Compose`] representation
     pub fn new(contents: &str) -> Result<Self, ValidationErrors> {
         let mut errors = ValidationErrors::new();
         let compose: Result<Self, ValidationError> = serde_yaml::from_str(contents)

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -13,6 +13,12 @@ use super::{configs, networks, secrets, services, volumes};
 use serde::{Deserialize, Serialize};
 use serde_yaml;
 
+/// Represents an entire [Docker Compose](https://docs.docker.com/compose/compose-file/) manifest
+/// 
+/// All fields other than the `services` field are optional. Optional fields are skipped
+/// from serialization if they are `None`
+/// 
+/// 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Compose {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -1,3 +1,5 @@
+//! Compose fields and validation
+
 use std::{collections::HashMap, fmt::Display};
 
 use crate::{
@@ -17,8 +19,6 @@ use serde_yaml;
 ///
 /// All fields other than the `services` field are optional. Optional fields are skipped
 /// from serialization if they are `None`
-///
-///
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Compose {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -40,7 +40,7 @@ pub struct Compose {
 }
 
 impl Compose {
-    /// Create a new [`Compose`]
+    /// Create a new [`Compose`] representation
     pub fn new(contents: &str) -> Result<Self, ValidationErrors> {
         let mut errors = ValidationErrors::new();
         let compose: Result<Self, ValidationError> = serde_yaml::from_str(contents)

--- a/src/compose.rs
+++ b/src/compose.rs
@@ -14,11 +14,11 @@ use serde::{Deserialize, Serialize};
 use serde_yaml;
 
 /// Represents an entire [Docker Compose](https://docs.docker.com/compose/compose-file/) manifest
-/// 
+///
 /// All fields other than the `services` field are optional. Optional fields are skipped
 /// from serialization if they are `None`
-/// 
-/// 
+///
+///
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Compose {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -40,6 +40,7 @@ pub struct Compose {
 }
 
 impl Compose {
+    /// Create a new [`Compose`]
     pub fn new(contents: &str) -> Result<Self, ValidationErrors> {
         let mut errors = ValidationErrors::new();
         let compose: Result<Self, ValidationError> = serde_yaml::from_str(contents)
@@ -72,6 +73,7 @@ impl Compose {
         }
     }
 
+    /// Validate top level networks
     fn validate_networks(
         compose: &Compose,
         networks: &HashMap<String, Option<Network>>,
@@ -84,6 +86,7 @@ impl Compose {
         }
     }
 
+    /// Validate top level volumes
     fn validate_volumes(
         compose: &Compose,
         volumes: &HashMap<String, Option<Volume>>,
@@ -96,6 +99,7 @@ impl Compose {
         }
     }
 
+    /// Validate top level configs
     fn validate_configs(
         compose: &Compose,
         configs: &HashMap<String, Option<Config>>,
@@ -108,6 +112,7 @@ impl Compose {
         }
     }
 
+    /// Validate top level secrets
     fn validate_secrets(
         compose: &Compose,
         secrets: &HashMap<String, Option<Secret>>,
@@ -120,6 +125,7 @@ impl Compose {
         }
     }
 
+    /// Validate services
     fn validate_services(
         compose: &Compose,
         services: &HashMap<String, Service>,
@@ -133,7 +139,7 @@ impl Compose {
 
 /// This trait needs to be implemented for top level elements
 pub(crate) trait Validate {
-    /// Validate that an attribute is valid within the context of the compose yaml
+    /// Validate that an attribute is valid within the context of the compose manifest
     ///
     /// Push all validation errors to the ValidationErrors so that users are able to see
     /// all of their errors at once, versus incrementally

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -5,8 +5,13 @@ use crate::{compose::Validate, errors::ValidationErrors};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub file: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub external: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -1,8 +1,11 @@
+//! Config fields and validation
+
 use crate::compose::Compose;
 use serde::{Deserialize, Serialize};
 
 use crate::{compose::Validate, errors::ValidationErrors};
 
+/// Represents the top level [Config](https://docs.docker.com/compose/compose-file/08-configs/) element
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,5 @@
+//! Library errors
+
 #[derive(Debug)]
 pub enum ValidationError {
     MissingField(String),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! `compose-validatr` is a library for validating and building valid manifests that are not dependent on the host system.
+//! `compose-validatr` is a library for validating and building valid [Docker Compose](https://docs.docker.com/compose/compose-file/) manifests that are not dependent on the host system.
 //!
 //! # Table of Contents
 //!
@@ -9,7 +9,7 @@
 //!
 //! # High-level Features
 //!
-//! - Create and validate a Compose structure from `&str`
+//! - Create and validate a Docker Compose structure from `&str`
 //! - Access the fields for a Compose manifest
 //! - View multiple validation errors at once
 //!  
@@ -24,7 +24,7 @@
 //!
 //! ```rust
 //! use compose_validatr::Compose;
-//! 
+//!
 //! let yaml = r#"
 //! services:
 //!   gitlab:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,25 @@
 //!
 //! ```rust
 //! use compose_validatr::Compose;
+//! 
+//! let yaml = r#"
+//! services:
+//!   gitlab:
+//!     image: gitlab/gitlab-ce:latest
+//!     container_name: gitlab
+//!     hostname: gitlab
+//!     restart: always
+//!     build:
+//!       context: .
+//!       dockerfile: webapp.Dockerfile
+//! "#;
+//!
+//! let compose = Compose::new(yaml).unwrap();
+//! compose.services.keys().for_each(|service_name| println!("Service: {service_name}"));
+//! ```
+//!
+//! ```rust
+//! use compose_validatr::Compose;
 //!
 //! let yaml = r#"
 //! version: '3.9'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! compose-validatr is a library for validating and building valid Docker Compose manifests that are not dependent on the host system.
+//! `compose-validatr` is a library for validating and building valid manifests that are not dependent on the host system.
 //!
 //! # Table of Contents
 //!
@@ -9,7 +9,8 @@
 //!
 //! # High-level Features
 //!
-//! - Create and validate a Compose structure from &str
+//! - Create and validate a Compose structure from `&str`
+//! - Access the fields for a Compose manifest
 //! - View multiple validation errors at once
 //!  
 //! # Purpose
@@ -146,6 +147,16 @@
 //! }
 //! ```
 
+#![warn(
+    clippy::all,
+    clippy::todo,
+    clippy::empty_enum,
+    clippy::inefficient_to_string,
+    clippy::str_to_string,
+    clippy::str_to_string,
+    clippy::missing_docs
+)]
+#![deny(unreachable_pub, unreachable_code, unsafe_code)]
 pub mod compose;
 pub mod configs;
 pub mod errors;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,151 @@
+//! compose-validatr is a library for validating and building valid Docker Compose manifests that are not dependent on the host system.
+//!
+//! # Table of Contents
+//!
+//! - [High-level features](#high-level-features)
+//! - [Purpose](#purpose)
+//! - [Examples](#examples)
+//!
+//!
+//! # High-level Features
+//!
+//! - Create and validate a Compose structure from &str
+//! - View multiple validation errors at once
+//!  
+//! # Purpose
+//!
+//! The main purpose of this library is for building and validating Docker Compose manifests
+//! in contexts that are agnostic to a host machine. This is useful for web applications
+//! that want to visualize existing Compose manifests or create valid manifests without
+//! caring if host files or devices are present.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use compose_validatr::Compose;
+//!
+//! let yaml = r#"
+//! version: '3.9'
+//! services:
+//!   gitlab:
+//!     image: gitlab/gitlab-ce:latest
+//!     container_name: gitlab
+//!     hostname: gitlab
+//!     restart: always
+//!     depends_on:
+//!       - postgres
+//!     ports:
+//!       - "8080:80"
+//!       - "8443:443"
+//!       - "8022:22"
+//!     environment:
+//!       GITLAB_ROOT_PASSWORD: eYPkjBbrtzX8eGVc
+//!       DATABASE_URL: "postgres://gitlab:eYPkjBbrtzX8eGVc@postgres:5432/gitlab"
+//!     volumes:
+//!       - ./gitlab/config:/etc/gitlab
+//!       - ./gitlab/logs:/var/log/gitlab
+//!       - ./gitlab/data:/var/opt/gitlab
+//!     shm_size: '256m'
+//!
+//!   registry:
+//!     image: registry:2
+//!     container_name: registry
+//!     hostname: registry
+//!     ports:
+//!       - "5000:5000"
+//!     volumes:
+//!       - registry:/var/lib/registry
+//!
+//!   sonarqube:
+//!     build:
+//!       context: ./sonarqube_image
+//!     container_name: sonarqube
+//!     hostname: sonarqube
+//!     restart: always
+//!     ports:
+//!       - "9000:9000"
+//!       - "9092:9092"
+//!     volumes:
+//!       - sonarqube:/opt/sonarqube/data
+//!       - sonarqube:/opt/sonarqube/logs
+//!       - sonarqube:/opt/sonarqube/extensions
+//!
+//!   jenkins:
+//!     build:
+//!       context: ./jenkins_image
+//!     container_name: jenkins
+//!     hostname: jenkins
+//!     restart: always
+//!     ports:
+//!       - "9080:8080"
+//!       - "50000:50000"
+//!     volumes:
+//!       - jenkins:/var/jenkins_home
+//!       - jenkins-data:/var/jenkins_home
+//!       - jenkins-docker-certs:/certs/client:ro
+//!     environment:
+//!       - JAVA_OPTS=-Djenkins.install.runSetupWizard=false
+//!       - DOCKER_HOST=tcp://docker:2376
+//!       - DOCKER_CERT_PATH=/certs/client
+//!       - DOCKER_TLS_VERIFY=1
+//!
+//!   jenkins-docker:
+//!     image: docker:dind
+//!     container_name: jenkins-docker
+//!     hostname: docker
+//!     privileged: true
+//!     environment:
+//!       - DOCKER_TLS_CERTDIR=/certs
+//!     volumes:
+//!       - /etc/docker/daemon.json:/etc/docker/daemon.json
+//!       - jenkins-docker-certs:/certs/client
+//!       - jenkins-data:/var/jenkins_home
+//!     ports:
+//!       - '2376:2376'
+//!     command: --storage-driver overlay2
+//!
+//!   postgres:
+//!     image: postgres:latest
+//!     container_name: postgres
+//!     hostname: postgres
+//!     restart: always
+//!     ports:
+//!       - "5432:5432"
+//!     volumes:
+//!       - postgres:/var/lib/postgresql/data
+//!     environment:
+//!       POSTGRES_DB: gitlab
+//!       POSTGRES_USER: gitlab
+//!       POSTGRES_PASSWORD: eYPkjBbrtzX8eGVc
+//!
+//! volumes:
+//!   sonarqube:
+//!   jenkins:
+//!   jenkins-docker-certs:
+//!   jenkins-data:
+//!   postgres:
+//!   registry:
+//!
+//! networks:
+//!   default:
+//!     driver: bridge
+//! "#;
+//!
+//! // Create a new `Compose` from the &str. This will return a Result<Compose, ValidationErrors>
+//! let compose = Compose::new(yaml);
+//! match &compose {
+//!   Ok(c) => {
+//!     // Compose is valid. A lot of Compose fields are optional, so maps are very useful here
+//!     c.version.as_ref().map(|v| println!("Version: {v}"));
+//!     ()
+//!   }
+//!   Err(errors) => {
+//!     // Compose had one or many errors
+//!     ()
+//!   }
+//! }
+//! ```
+
 pub mod compose;
 pub mod configs;
 pub mod errors;
@@ -5,3 +153,5 @@ pub mod networks;
 pub mod secrets;
 pub mod services;
 pub mod volumes;
+
+pub use crate::compose::Compose;

--- a/src/networks.rs
+++ b/src/networks.rs
@@ -1,3 +1,5 @@
+//! Network fields and validation
+
 use crate::compose::Compose;
 use ipnetwork::IpNetwork;
 use serde::{Deserialize, Serialize};
@@ -9,6 +11,7 @@ use crate::{
     services::Labels,
 };
 
+/// Represents the top level [Network](https://docs.docker.com/compose/compose-file/06-networks/) element
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Network {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/networks.rs
+++ b/src/networks.rs
@@ -11,23 +11,49 @@ use crate::{
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Network {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub attachable: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ipam: Option<Ipam>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub driver: Option<Driver>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub driver_opts: Option<HashMap<String, String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub enable_ipv6: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub external: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<Vec<Config>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub internal: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Ipam {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub driver: Option<Driver>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<Config>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<HashMap<String, String>>,
 }
 
@@ -42,9 +68,16 @@ pub enum Driver {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Config {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub subnet: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ip_range: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gateway: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aux_addresses: Option<HashMap<String, String>>,
 }
 

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -1,8 +1,11 @@
+//! Secret fields and validation
+
 use crate::compose::Compose;
 use serde::{Deserialize, Serialize};
 
 use crate::{compose::Validate, errors::ValidationErrors};
 
+/// Represents the top level [Secrets](https://docs.docker.com/compose/compose-file/09-secrets/) element
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Secret {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/secrets.rs
+++ b/src/secrets.rs
@@ -5,9 +5,16 @@ use crate::{compose::Validate, errors::ValidationErrors};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Secret {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub file: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub external: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 

--- a/src/services.rs
+++ b/src/services.rs
@@ -18,88 +18,253 @@ use crate::{compose::Validate, errors::ValidationErrors};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Service {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub attach: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub build: Option<build::Build>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub blkio_config: Option<blkio_config::BlkioConfig>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_count: Option<u8>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_percent: Option<f32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_shares: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_period: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_quota: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_rt_runtime: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpu_rt_period: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpus: Option<f32>, // deprecated
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpuset: Option<u8>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cap_add: Option<Vec<Capabilities>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cap_drop: Option<Vec<Capabilities>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cgroup: Option<Cgroup>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cgroup_parent: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub command: Option<Command>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub configs: Option<Vec<Config>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub container_name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub credential_spec: Option<CredentialSpec>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub depends_on: Option<DependsOn>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub deploy: Option<deploy::Deploy>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_cgroup_rules: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub devices: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dns: Option<Labels>, // TODO: maybe validate as ipv4
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dns_opt: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dns_search: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub domainname: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub entrypoint: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub env_file: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub environment: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub expose: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extends: Option<Extends>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub external_links: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_hosts: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub group_add: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub healthcheck: Option<healthcheck::HealthCheck>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub hostname: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub image: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub init: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ipc: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub uts: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub isolation: Option<String>, // TODO: Verify this
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub links: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub logging: Option<logging::Logging>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub network_mode: Option<String>, // TODO: Maybe make enum for this?
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub networks: Option<networks::Networks>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mac_address: Option<String>,
-    pub mem_limit: Option<String>,       // deprecated
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mem_limit: Option<String>, // deprecated
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mem_reservation: Option<String>, // deprecated
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mem_swappiness: Option<u8>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub memswap_limit: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub oom_kill_disable: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub oom_score_adj: Option<i16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pids_limit: Option<u32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub platform: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ports: Option<ports::Ports>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub privileged: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub profiles: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pull_policy: Option<PullPolicy>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub restart: Option<Restart>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub scale: Option<u32>, // deprecated
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub secrets: Option<secrets::Secrets>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub secruity_opt: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shm_size: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stdin_open: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_grace_period: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub stop_signal: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub storage_opt: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub sysctls: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tmpfs: Option<Tmpfs>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tty: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ulimits: Option<Ulimits>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub user: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub userns_mode: Option<String>,
-    pub volumes: Option<Vec<volumes::Volumes>>, // enum
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volumes: Option<Vec<volumes::Volumes>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub volumes_from: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub working_dir: Option<String>,
 }
 
@@ -149,8 +314,13 @@ pub enum Command {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct CredentialSpec {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub file: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub registry: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub config: Option<String>, // must be valid config
 }
 
@@ -163,8 +333,13 @@ pub enum DependsOn {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DependsOnDetail {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub restart: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub condition: Option<DependsOnCondition>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub required: Option<bool>,
 }
 

--- a/src/services.rs
+++ b/src/services.rs
@@ -223,7 +223,7 @@ pub struct Service {
     pub scale: Option<u32>, // deprecated
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub secrets: Option<secrets::Secrets>,
+    pub secrets: Option<Vec<secrets::Secret>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub secruity_opt: Option<Vec<String>>,
@@ -468,7 +468,9 @@ impl Service {
     }
 
     fn validate_secrets(&self, ctx: &Compose, errors: &mut ValidationErrors) {
-        self.secrets.as_ref().map(|s| s.validate(ctx, errors));
+        self.secrets
+            .as_ref()
+            .map(|s| s.iter().for_each(|s| s.validate(ctx, errors)));
     }
 
     fn validate_volumes(&self, ctx: &Compose, errors: &mut ValidationErrors) {

--- a/src/services.rs
+++ b/src/services.rs
@@ -1,3 +1,5 @@
+//! Service fields and validation
+
 mod blkio_config;
 mod build;
 mod deploy;
@@ -16,6 +18,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{compose::Validate, errors::ValidationErrors};
 
+/// Represents the top level [Service](https://docs.docker.com/compose/compose-file/05-services/) element
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Service {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/services/blkio_config.rs
+++ b/src/services/blkio_config.rs
@@ -5,10 +5,20 @@ use crate::compose::{Compose, Validate};
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BlkioConfig {
     pub weight: u16,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub weight_device: Option<Vec<WeightDevice>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_read_bps: Option<Vec<DeviceReadBps>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_read_iops: Option<Vec<DeviceReadIops>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_write_bps: Option<Vec<DeviceWriteBps>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device_write_iops: Option<Vec<DeviceWriteIops>>,
 }
 

--- a/src/services/build.rs
+++ b/src/services/build.rs
@@ -18,24 +18,61 @@ pub enum Build {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct BuildDetails {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub context: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dockerfile: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub dockerfile_inline: Option<String>, // dockerfile must NOT be defined
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub args: Option<BuildArgs>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ssh: Option<SshArgs>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_from: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cache_to: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub additional_contexts: Option<AdditionalContexts>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub extra_hosts: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub isolation: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub privileged: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub no_cache: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pull: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub shm_size: Option<ShmSize>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub target: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub secrets: Option<Vec<BuildSecret>>, // must be defined secrets
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub platforms: Option<Vec<String>>,
 }
 

--- a/src/services/deploy.rs
+++ b/src/services/deploy.rs
@@ -5,20 +5,40 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Deploy {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub replicas: Option<u16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub enpoint_mode: Option<EndpointMode>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub mode: Option<Mode>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub placement: Option<Placement>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub resources: Option<Resources>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub restart_policy: Option<RestartPolicy>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub rollback_config: Option<RollbackConfig>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub update_config: Option<UpdateConfig>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Placement {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub constraints: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub preferences: Option<Labels>,
 }
 
@@ -38,16 +58,28 @@ pub enum Mode {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Resources {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub limits: Option<Limits>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reservations: Option<Reservations>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Limits {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub cpus: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub memory: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pids: Option<u16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub devices: Option<Vec<DriverCapabilities>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub capabilities: Option<Vec<DriverCapabilities>>,
 }
 
@@ -60,9 +92,16 @@ pub enum DriverCapabilities {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RestartPolicy {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub condition: Option<RestartCondition>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delay: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_attempts: Option<u16>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub window: Option<String>,
 }
 
@@ -82,21 +121,43 @@ pub struct Reservations {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct RollbackConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub parallelism: Option<u8>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delay: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_action: Option<FailureAction>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub monitor: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_failure_ration: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub order: Option<Order>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct UpdateConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub parallelism: Option<u8>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub delay: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub failure_action: Option<FailureAction>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub monitor: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_failure_ration: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub order: Option<Order>,
 }
 

--- a/src/services/healthcheck.rs
+++ b/src/services/healthcheck.rs
@@ -4,12 +4,25 @@ use crate::compose::{Compose, Validate};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct HealthCheck {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<Test>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub interval: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub timeout: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub retries: Option<u8>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_period: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_interval: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub disable: Option<bool>,
 }
 

--- a/src/services/logging.rs
+++ b/src/services/logging.rs
@@ -4,7 +4,10 @@ use crate::compose::{Compose, Validate};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Logging {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub driver: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<Options>,
 }
 

--- a/src/services/networks.rs
+++ b/src/services/networks.rs
@@ -30,7 +30,67 @@ pub struct NetworkOptions {
 }
 
 impl Validate for Networks {
-    fn validate(&self, _: &Compose, _: &mut crate::errors::ValidationErrors) {
-        ()
+    fn validate(&self, ctx: &Compose, errors: &mut crate::errors::ValidationErrors) {
+        match self {
+            Networks::List(n) => {
+                ctx.networks.as_ref().map(|available_networks| {
+                    n.iter().for_each(|network| {
+                        if !available_networks.contains_key(network) {
+                            errors.add_error(crate::errors::ValidationError::InvalidValue(
+                                format!("Service networks reference an unknown network: {network}"),
+                            ));
+                        }
+                    });
+                });
+            }
+            Networks::Map(n) => {
+                ctx.networks.as_ref().map(|available_networks| {
+                    n.keys().for_each(|network| {
+                        if !available_networks.contains_key(network) {
+                            errors.add_error(crate::errors::ValidationError::InvalidValue(
+                                format!("Service networks reference an unknown network: {network}"),
+                            ));
+                        }
+                    });
+                });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_network() {
+        let yaml = r#"
+        services:
+          some-service:
+            networks:
+              - hello
+              - world
+        networks:
+            some-network:
+            other-network:
+        "#;
+        let compose = Compose::new(yaml);
+        assert!(compose.is_err());
+    }
+
+    #[test]
+    fn valid_network() {
+        let yaml = r#"
+        services:
+          some-service:
+            networks:
+              - some-network
+              - other-network
+        networks:
+            some-network:
+            other-network:
+        "#;
+        let compose = Compose::new(yaml);
+        assert!(compose.is_ok());
     }
 }

--- a/src/services/networks.rs
+++ b/src/services/networks.rs
@@ -13,15 +13,24 @@ pub enum Networks {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct NetworkOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub aliases: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ipv4_address: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub ipv6_address: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub link_local_ips: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<u16>,
 }
 
 impl Validate for Networks {
     fn validate(&self, _: &Compose, _: &mut crate::errors::ValidationErrors) {
-        todo!()
+        ()
     }
 }

--- a/src/services/volumes.rs
+++ b/src/services/volumes.rs
@@ -23,10 +23,20 @@ pub struct LongVolumeOptions {
     pub volume_type: VolumeType,
     pub source: String,
     pub target: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bind: Option<Bind>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub volume: Option<VolumeOptions>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tmpfs: Option<Tmpfs>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub consistency: Option<String>,
 }
 

--- a/src/volumes.rs
+++ b/src/volumes.rs
@@ -7,18 +7,31 @@ use crate::services::Labels;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Volume {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub driver: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub driver_opts: Option<DriverOpts>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub external: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub labels: Option<Labels>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DriverOpts {
-    #[serde(rename = "type")]
+    #[serde(rename = "type", skip_serializing_if = "Option::is_none")]
     pub driver_type: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub o: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub device: Option<String>,
 }
 

--- a/src/volumes.rs
+++ b/src/volumes.rs
@@ -1,3 +1,5 @@
+//! Volume fields and validation
+
 use serde::{Deserialize, Serialize};
 
 use crate::compose::Compose;
@@ -5,6 +7,7 @@ use crate::compose::Validate;
 use crate::errors::ValidationErrors;
 use crate::services::Labels;
 
+/// Represents the top level [Volume](https://docs.docker.com/compose/compose-file/07-volumes/) element
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Volume {
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
- Added some initial documentation
- Skip serialization of fields that are `None`
  - This will be useful if you are outputting the validated `Compose` structure to a file or stdout
- Added missing tests for service networks and secrets
- Small refactors